### PR TITLE
fix(frontend): import MkTab component in drop-and-fusion page

### DIFF
--- a/packages/frontend/src/pages/drop-and-fusion.vue
+++ b/packages/frontend/src/pages/drop-and-fusion.vue
@@ -97,6 +97,7 @@ import MkButton from '@/components/MkButton.vue';
 import { i18n } from '@/i18n.js';
 import MkSelect from '@/components/MkSelect.vue';
 import MkSwitch from '@/components/MkSwitch.vue';
+import MkTab from '@/components/MkTab.vue';
 import { misskeyApiGet } from '@/utility/misskey-api.js';
 
 const gameMode = ref<'normal' | 'square' | 'yen' | 'sweets' | 'space'>('normal');


### PR DESCRIPTION
This pull request makes a minor update to the `drop-and-fusion.vue` file by adding a new component import.

* [`packages/frontend/src/pages/drop-and-fusion.vue`](diffhunk://#diff-b824b4dfcdadf183132e088afedfa941e10a3bceb9c00467f00a2a4800480428R100): Added the `MkTab` component import, likely to support new functionality or UI enhancements.