### PR TITLE
fix(fribtebd): add 'nowarning' option to server disconnected behavior…

### DIFF
--- a/packages/frontend/src/pages/settings/preferences.vue
+++ b/packages/frontend/src/pages/settings/preferences.vue
@@ -664,6 +664,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 									<option value="reload">{{ i18n.ts._serverDisconnectedBehavior.reload }}</option>
 									<option value="dialog">{{ i18n.ts._serverDisconnectedBehavior.dialog }}</option>
 									<option value="quiet">{{ i18n.ts._serverDisconnectedBehavior.quiet }}</option>
+									<option value="nowarning">{{ i18n.ts._serverDisconnectedBehavior.nowarning }}</option>
 								</MkSelect>
 							</MkPreferenceContainer>
 						</SearchMarker>


### PR DESCRIPTION
This pull request adds a new option to the server disconnected behavior settings in the `preferences.vue` file.

* [`packages/frontend/src/pages/settings/preferences.vue`](diffhunk://#diff-a66570e2852a932d658811a571004c7c99e787b67605518e214fb4c24c67eb47R667): Added a new `<option>` with the value `nowarning` to the server disconnected behavior dropdown, allowing users to select a "no warning" behavior.