### PR TITLE
Meilisearch回りのPolester向けコンフィグをデフォルトに戻した

### DIFF
--- a/packages/backend/src/GlobalModule.ts
+++ b/packages/backend/src/GlobalModule.ts
@@ -44,7 +44,7 @@ const $meilisearch: Provider = {
 			}
 
 			return new MeiliSearch({
-				host: `${config.meilisearch.ssl ? 'https' : 'http'}://${config.meilisearch.host}${config.meilisearch.port ? ':' + config.meilisearch.port : ''}`,
+				host: `${config.meilisearch.ssl ? 'https' : 'http'}://${config.meilisearch.host}:${config.meilisearch.port}`,
 				apiKey: config.meilisearch.apiKey,
 			});
 		} else {

--- a/packages/backend/src/core/SearchService.ts
+++ b/packages/backend/src/core/SearchService.ts
@@ -132,8 +132,8 @@ export class SearchService {
 	@bindThis
 	public async indexNote(note: MiNote): Promise<void> {
 		if (!this.meilisearch) return;
-		//if (note.text == null && note.cw == null) return;
-		//if (!['home', 'public'].includes(note.visibility)) return;
+		if (note.text == null && note.cw == null) return;
+		if (!['home', 'public'].includes(note.visibility)) return;
 
 		switch (this.meilisearchIndexScope) {
 			case 'global':
@@ -167,7 +167,7 @@ export class SearchService {
 	@bindThis
 	public async unindexNote(note: MiNote): Promise<void> {
 		if (!this.meilisearch) return;
-		//if (!['home', 'public'].includes(note.visibility)) return;
+		if (!['home', 'public'].includes(note.visibility)) return;
 
 		await this.meilisearchNoteIndex?.deleteDocument(note.id);
 	}


### PR DESCRIPTION
This pull request includes updates to the MeiliSearch configuration and the `SearchService` class to improve functionality and remove commented-out code. The most important changes include fixing the MeiliSearch host URL construction and re-enabling previously commented-out validation checks in the `indexNote` and `unindexNote` methods.

### MeiliSearch Configuration Updates:
* Fixed the `host` URL construction in `GlobalModule.ts` to always include the port, ensuring consistent behavior when connecting to MeiliSearch. (`packages/backend/src/GlobalModule.ts`, [packages/backend/src/GlobalModule.tsL47-R47](diffhunk://#diff-8d5253764599c7baa48b22c48784e31f5b49a6486106becc398f6ce218164246L47-R47))

### `SearchService` Improvements:
* Re-enabled validation checks in the `indexNote` method to skip indexing notes without text or visibility outside "home" and "public." (`packages/backend/src/core/SearchService.ts`, [packages/backend/src/core/SearchService.tsL135-R136](diffhunk://#diff-12cc49a66eaffc4aa28acdbbd4d93fda1771fe2144c63e1f141d01476480122dL135-R136))
* Re-enabled validation checks in the `unindexNote` method to skip unindexing notes with visibility outside "home" and "public." (`packages/backend/src/core/SearchService.ts`, [packages/backend/src/core/SearchService.tsL170-R170](diffhunk://#diff-12cc49a66eaffc4aa28acdbbd4d93fda1771fe2144c63e1f141d01476480122dL170-R170))